### PR TITLE
Fix 4 bugs about the network in the server side. 修复模组在服务端不可用的 bug。

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ repositories {
 }
 
 base {
-    archivesName = mod_id
+    archivesName = mod_id+'-client_hacked'
 }
 
 // Mojang ships Java 21 to end users starting in 1.20.5, so mods should target Java 21.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://mirrors.tencent.com/gradle/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/top/birthcat/journalmod/client/ClientJournalHolder.java
+++ b/src/main/java/top/birthcat/journalmod/client/ClientJournalHolder.java
@@ -5,7 +5,10 @@
 
 package top.birthcat.journalmod.client;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.language.I18n;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.item.ItemStack;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.bus.api.SubscribeEvent;
@@ -23,7 +26,6 @@ import java.util.List;
  * get rid of LocalPlayer clone.
  * this also enable recover after logout.
  */
-@OnlyIn(Dist.CLIENT)
 @EventBusSubscriber(value = Dist.CLIENT)
 public class ClientJournalHolder {
 
@@ -36,10 +38,10 @@ public class ClientJournalHolder {
         return journalData;
     }
 
-    public static void setJournal(List<String> newJournal) {
+    public static void setJournal(List<String> newJournal, ItemStack stack,int slot) {
         journalData = newJournal;
         if (DEFAULT_DATA != journalData) {
-            PacketDistributor.sendToServer(new JournalDataPacket(newJournal));
+            PacketDistributor.sendToServer(new JournalDataPacket(newJournal, (CompoundTag) stack.save(Minecraft.getInstance().level.registryAccess()),slot));
         }
     }
 

--- a/src/main/java/top/birthcat/journalmod/client/ClientJournalHolder.java
+++ b/src/main/java/top/birthcat/journalmod/client/ClientJournalHolder.java
@@ -5,12 +5,8 @@
 
 package top.birthcat.journalmod.client;
 
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.language.I18n;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.world.item.ItemStack;
 import net.neoforged.api.distmarker.Dist;
-import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent;
@@ -38,10 +34,10 @@ public class ClientJournalHolder {
         return journalData;
     }
 
-    public static void setJournal(List<String> newJournal, ItemStack stack,int slot) {
+    public static void setJournal(List<String> newJournal,int slot) {
         journalData = newJournal;
         if (DEFAULT_DATA != journalData) {
-            PacketDistributor.sendToServer(new JournalDataPacket(newJournal, (CompoundTag) stack.save(Minecraft.getInstance().level.registryAccess()),slot));
+            PacketDistributor.sendToServer(new JournalDataPacket(newJournal,slot));
         }
     }
 

--- a/src/main/java/top/birthcat/journalmod/client/ClientSetupHandler.java
+++ b/src/main/java/top/birthcat/journalmod/client/ClientSetupHandler.java
@@ -8,6 +8,7 @@ package top.birthcat.journalmod.client;
 import com.mojang.blaze3d.platform.InputConstants;
 import net.minecraft.client.KeyMapping;
 import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.client.event.RegisterKeyMappingsEvent;
@@ -16,6 +17,7 @@ import org.lwjgl.glfw.GLFW;
 
 import static top.birthcat.journalmod.JournalMod.MODID;
 
+@OnlyIn(Dist.CLIENT)
 @EventBusSubscriber(modid = MODID, bus = EventBusSubscriber.Bus.MOD, value = Dist.CLIENT)
 public class ClientSetupHandler {
 

--- a/src/main/java/top/birthcat/journalmod/client/JournalEditScreen.java
+++ b/src/main/java/top/birthcat/journalmod/client/JournalEditScreen.java
@@ -10,7 +10,6 @@ import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
 import net.minecraft.Util;
 import net.minecraft.client.GameNarrator;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.StringSplitter;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
@@ -21,13 +20,10 @@ import net.minecraft.client.gui.screens.inventory.BookViewScreen;
 import net.minecraft.client.gui.screens.inventory.PageButton;
 import net.minecraft.client.renderer.Rect2i;
 import net.minecraft.client.renderer.RenderType;
-import net.minecraft.core.Holder;
-import net.minecraft.core.component.DataComponentMap;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.network.chat.CommonComponents;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.Style;
-import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.network.Filterable;
 import net.minecraft.util.StringUtil;
 import net.minecraft.world.InteractionHand;
@@ -35,9 +31,6 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.component.WritableBookContent;
-import net.minecraft.world.item.enchantment.Enchantment;
-import net.minecraft.world.item.enchantment.EnchantmentEffectComponents;
-import net.minecraft.world.item.enchantment.Enchantments;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.api.distmarker.OnlyIn;
 import org.apache.commons.lang3.StringUtils;
@@ -45,7 +38,6 @@ import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.apache.commons.lang3.mutable.MutableInt;
 
 import javax.annotation.Nullable;
-import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.List;
 import java.util.ListIterator;
@@ -111,6 +103,7 @@ public class JournalEditScreen extends Screen {
             }
         }
 
+        //For ServerboundSetBookPacket
         if(this.book!=null){
             for (Slot slot : owner.inventoryMenu.slots) {
                 if(slot.getItem().equals(book)){
@@ -155,11 +148,7 @@ public class JournalEditScreen extends Screen {
         }).bounds(this.width / 2 + 2, 196, 98, 20).build());
         this.writeButton = this.addRenderableWidget(Button.builder(Component.translatable("book.journalmod.transcription"), p_98177_ -> {
             this.minecraft.setScreen(null);
-            try {
-                this.writeToBook();
-            } catch (IllegalAccessException e) {
-                e.printStackTrace();
-            }
+            this.writeToBook();
             this.saveChanges();
         }).bounds(this.width / 2 - 100, 196, 98, 20).build());
         int i = (this.width - IMAGE_WIDTH) / 2;
@@ -168,7 +157,7 @@ public class JournalEditScreen extends Screen {
         this.updateButtonVisibility();
     }
 
-    private void writeToBook() throws IllegalAccessException {
+    private void writeToBook() {
         this.book.set(DataComponents.WRITABLE_BOOK_CONTENT, new WritableBookContent(this.pages.stream().map(Filterable::passThrough).toList()));
     }
 
@@ -211,7 +200,7 @@ public class JournalEditScreen extends Screen {
     private void saveChanges() {
         if (this.isModified) {
             this.eraseEmptyTrailingPages();
-            ClientJournalHolder.setJournal(pages,this.book,this.slot);
+            ClientJournalHolder.setJournal(pages,this.slot);
         }
     }
 

--- a/src/main/java/top/birthcat/journalmod/client/JournalEditScreen.java
+++ b/src/main/java/top/birthcat/journalmod/client/JournalEditScreen.java
@@ -93,25 +93,19 @@ public class JournalEditScreen extends Screen {
         var writablebookcontent = mainHandItem.get(DataComponents.WRITABLE_BOOK_CONTENT);
         if (writablebookcontent != null) {
             this.book = mainHandItem ;
+            this.slot = owner.getInventory().selected;
         } else {
             var offHandItem = owner.getItemInHand(InteractionHand.OFF_HAND);
             writablebookcontent = offHandItem.get(DataComponents.WRITABLE_BOOK_CONTENT);
             if (writablebookcontent != null) {
                 this.book = offHandItem ;
+                this.slot = 40;
             } else {
                 this.book = null;
             }
         }
 
-        //For ServerboundSetBookPacket
-        if(this.book!=null){
-            for (Slot slot : owner.inventoryMenu.slots) {
-                if(slot.getItem().equals(book)){
-                    this.slot = slot.index;
-                    break;
-                }
-            }
-        }
+        //For ServerboundEditBookPacket
 
         this.pages.addAll(pages);
         if (this.pages.isEmpty()) {

--- a/src/main/java/top/birthcat/journalmod/client/JournalEditScreen.java
+++ b/src/main/java/top/birthcat/journalmod/client/JournalEditScreen.java
@@ -85,7 +85,6 @@ public class JournalEditScreen extends Screen {
     private DisplayCache displayCache = DisplayCache.EMPTY;
     private Component pageMsg = CommonComponents.EMPTY;
     private final ItemStack book;
-    private int slot = -1;
     private final Player owner;
 
     public JournalEditScreen(Player owner, List<String> pages) {
@@ -95,13 +94,11 @@ public class JournalEditScreen extends Screen {
         var writablebookcontent = mainHandItem.get(DataComponents.WRITABLE_BOOK_CONTENT);
         if (writablebookcontent != null) {
             this.book = mainHandItem ;
-            this.slot = owner.getInventory().selected;
         } else {
             var offHandItem = owner.getItemInHand(InteractionHand.OFF_HAND);
             writablebookcontent = offHandItem.get(DataComponents.WRITABLE_BOOK_CONTENT);
             if (writablebookcontent != null) {
                 this.book = offHandItem ;
-                this.slot = 40;
             } else {
                 this.book = null;
             }
@@ -196,7 +193,7 @@ public class JournalEditScreen extends Screen {
     private void saveChanges() {
         if (this.isModified) {
             this.eraseEmptyTrailingPages();
-            ClientJournalHolder.setJournal(pages,this.slot);
+            ClientJournalHolder.setJournal(pages,this.owner.getMainHandItem().has(DataComponents.WRITABLE_BOOK_CONTENT)?this.owner.getInventory().selected:(this.owner.getOffhandItem().has(DataComponents.WRITABLE_BOOK_CONTENT)?40:-1));
         }
     }
 

--- a/src/main/java/top/birthcat/journalmod/client/JournalEditScreen.java
+++ b/src/main/java/top/birthcat/journalmod/client/JournalEditScreen.java
@@ -16,6 +16,7 @@ import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.font.TextFieldHelper;
 import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.gui.screens.inventory.BookEditScreen;
 import net.minecraft.client.gui.screens.inventory.BookViewScreen;
 import net.minecraft.client.gui.screens.inventory.PageButton;
 import net.minecraft.client.renderer.Rect2i;
@@ -85,10 +86,11 @@ public class JournalEditScreen extends Screen {
     private Component pageMsg = CommonComponents.EMPTY;
     private final ItemStack book;
     private int slot = -1;
+    private final Player owner;
 
     public JournalEditScreen(Player owner, List<String> pages) {
         super(GameNarrator.NO_TITLE);
-
+        this.owner = owner;
         var mainHandItem = owner.getItemInHand(InteractionHand.MAIN_HAND);
         var writablebookcontent = mainHandItem.get(DataComponents.WRITABLE_BOOK_CONTENT);
         if (writablebookcontent != null) {

--- a/src/main/java/top/birthcat/journalmod/client/KeyPressHandler.java
+++ b/src/main/java/top/birthcat/journalmod/client/KeyPressHandler.java
@@ -15,7 +15,7 @@ import net.neoforged.neoforge.client.event.ClientTickEvent;
 import static top.birthcat.journalmod.client.ClientSetupHandler.OPEN_MAP;
 
 @OnlyIn(Dist.CLIENT)
-@EventBusSubscriber
+@EventBusSubscriber(value = Dist.CLIENT)
 public class KeyPressHandler {
 
     @SubscribeEvent

--- a/src/main/java/top/birthcat/journalmod/common/AttachmentTypes.java
+++ b/src/main/java/top/birthcat/journalmod/common/AttachmentTypes.java
@@ -6,7 +6,7 @@
 package top.birthcat.journalmod.common;
 
 import com.mojang.serialization.Codec;
-import net.minecraft.client.resources.language.I18n;
+import net.minecraft.network.chat.Component;
 import net.neoforged.neoforge.attachment.AttachmentType;
 import net.neoforged.neoforge.attachment.IAttachmentHolder;
 import net.neoforged.neoforge.registries.DeferredRegister;
@@ -34,7 +34,7 @@ public class AttachmentTypes {
 
     private static List<String> defaultContent(IAttachmentHolder holder) {
         return List.of(
-                I18n.get("book.journalmod.default.content")
+                Component.translatable("book.journalmod.default.content").getString()
         );
     }
 

--- a/src/main/java/top/birthcat/journalmod/common/JournalDataPacket.java
+++ b/src/main/java/top/birthcat/journalmod/common/JournalDataPacket.java
@@ -6,10 +6,13 @@
 package top.birthcat.journalmod.common;
 
 import io.netty.buffer.ByteBuf;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.PacketDecoder;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import top.birthcat.journalmod.JournalMod;
 
@@ -20,7 +23,9 @@ import java.util.List;
  * but is bidirectional.
  */
 public record JournalDataPacket(
-        List<String> pages
+        List<String> pages,
+        CompoundTag stackData,
+        int slot
 ) implements CustomPacketPayload {
 
     public static final int MAX_LEN_PER_PAGE = 1024;
@@ -31,6 +36,10 @@ public record JournalDataPacket(
     public static final StreamCodec<ByteBuf, JournalDataPacket> STREAM_CODEC = StreamCodec.composite(
             ByteBufCodecs.stringUtf8(MAX_LEN_PER_PAGE).apply(ByteBufCodecs.list(MAX_PAGES)),
             JournalDataPacket::pages,
+            ByteBufCodecs.COMPOUND_TAG,
+            JournalDataPacket::stackData,
+            ByteBufCodecs.INT,
+            JournalDataPacket::slot,
             JournalDataPacket::new
     );
 

--- a/src/main/java/top/birthcat/journalmod/common/JournalDataPacket.java
+++ b/src/main/java/top/birthcat/journalmod/common/JournalDataPacket.java
@@ -6,13 +6,10 @@
 package top.birthcat.journalmod.common;
 
 import io.netty.buffer.ByteBuf;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.network.PacketDecoder;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import top.birthcat.journalmod.JournalMod;
 
@@ -24,7 +21,6 @@ import java.util.List;
  */
 public record JournalDataPacket(
         List<String> pages,
-        CompoundTag stackData,
         int slot
 ) implements CustomPacketPayload {
 
@@ -36,8 +32,6 @@ public record JournalDataPacket(
     public static final StreamCodec<ByteBuf, JournalDataPacket> STREAM_CODEC = StreamCodec.composite(
             ByteBufCodecs.stringUtf8(MAX_LEN_PER_PAGE).apply(ByteBufCodecs.list(MAX_PAGES)),
             JournalDataPacket::pages,
-            ByteBufCodecs.COMPOUND_TAG,
-            JournalDataPacket::stackData,
             ByteBufCodecs.INT,
             JournalDataPacket::slot,
             JournalDataPacket::new

--- a/src/main/java/top/birthcat/journalmod/server/AttachmentSyncHandler.java
+++ b/src/main/java/top/birthcat/journalmod/server/AttachmentSyncHandler.java
@@ -5,7 +5,9 @@
 
 package top.birthcat.journalmod.server;
 
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.item.ItemStack;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent;
@@ -18,16 +20,25 @@ import static top.birthcat.journalmod.common.AttachmentTypes.ATT_JOURNAL;
 @EventBusSubscriber
 public class AttachmentSyncHandler {
 
+    public static final CompoundTag EMPTY = new CompoundTag();
+
     @SubscribeEvent
     public static void syncOnLogin(PlayerEvent.PlayerLoggedInEvent e) {
         var player = e.getEntity();
         if (player instanceof ServerPlayer sPlayer) {
             var sidePages = player.getData(ATT_JOURNAL);
-            PacketDistributor.sendToPlayer(sPlayer, new JournalDataPacket(sidePages));
+            PacketDistributor.sendToPlayer(sPlayer, new JournalDataPacket(sidePages, new CompoundTag(),-1));
         }
     }
 
     public static void syncOnEdit(JournalDataPacket packet, IPayloadContext ctx) {
         ctx.player().setData(ATT_JOURNAL, packet.pages());
+        if(packet.stackData()!=EMPTY && packet.slot()!=-1){
+            try {
+                ctx.player().inventoryMenu.setItem(packet.slot(), 0,ItemStack.parseOptional(ctx.player().level().registryAccess(),packet.stackData()));
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixed bugs:
bug1: I18n is a client class that crashes incorrectly on the server side
The bug2:ClientJournalHolder class was mistakenly annotated with OnlyIn(Dist.CLIENT), causing the server to fail to load and crash
The bug3: KeyPressHandler class has no OnlyIn(di.client) annotation, and EventBusSubscriber does not include the value=Dist.CLIENT parameter, causing it to crash when loaded by the server
bug4: It is found that the data in the book cannot be synchronized after clicking the transcription at the server, and the data is reset by the server when the book and pen are thrown out and picked up
已修复的bug：
bug1: I18n为客户端类，在服务端时报错崩溃
bug2:ClientJournalHolder类被误加OnlyIn(Dist.CLIENT) 注解导致服务端无法加载崩溃
bug3: KeyPressHandler 类既没有 OnlyIn(Dist.CLIENT) 注解，EventBusSubscriber也没有加入 value=Dist.CLIENT 参数导致被服务端加载导致崩溃
bug4:在服务端时点击抄录后发现无法同步书内数据，将书与笔扔出再捡回时其数据被服务端重置